### PR TITLE
Fixed fatal error in UpUp options

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/UpUp/1.1.0/upup.min.js"></script>
     <script>
         UpUp.start({
-            'content-url': 'index.html',
+            'content-url': '/index.html',
             'assets': ['/assets/css/style.css', 'https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css', 'https://code.jquery.com/jquery-3.4.1.slim.min.js', 'https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js', 'https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js', 'https://kit.fontawesome.com/80d83fd1c9.js', '/assets/js/index.js'],
             'service-worker-url': '/upup.sw.min.js'
         });


### PR DESCRIPTION
This fix to PR #7 officially closes Issue #2. Everything is working offline. However, Font Awesome icons refuse to display. I suspect the CDN "Kits". 

Possible fixes:
1. Use a more accessible icon pack.
2. Abandon their CDN, host locally.